### PR TITLE
fix(security): bump uuid to ^14.0.0 (GHSA-w5hq-g745-h8pq)

### DIFF
--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -10,7 +10,7 @@ const chalk = require("chalk");
 const emoji = require("node-emoji");
 var searchFileUp = require("./searchFileUp");
 var hierarchyReporter = require("./hierarchyReporter");
-const guid = require("uuid/v4");
+const { v4: guid } = require("uuid");
 const isBase64 = (data) =>
   /^(?:[A-Z0-9+\/]{4})*(?:[A-Z0-9+\/]{2}==|[A-Z0-9+\/]{3}=|[A-Z0-9+\/]{4})$/i.test(
     data

--- a/package.json
+++ b/package.json
@@ -175,7 +175,7 @@
     "lodash": "^4.17.11",
     "node-emoji": "^1.10.0",
     "open": "^6.4.0",
-    "uuid": "^3.3.3"
+    "uuid": "^14.0.0"
   },
   "devDependencies": {
     "chai": "^4.2.0",


### PR DESCRIPTION
## Summary

`uuid <14.0.0` is flagged by image vulnerability scanners as **GHSA-w5hq-g745-h8pq** (medium, CVSS 6.30) — the v3/v5/v6 buffer-write API does not reject out-of-range writes. Bump the dep to `^14.0.0` and modernize the import in [`lib/reporter.js:13`](https://github.com/LambdaTest/cucumber-html-reporter/blob/develop/lib/reporter.js#L13).

The legacy `uuid/v4` subpath was removed in uuid v7+, so

```js
const guid = require("uuid/v4");
```

is replaced with the equivalent named-export form

```js
const { v4: guid } = require("uuid");
```

`guid` is still a function reference passed to mustache templates at `reporter.js:216` and `:544` — no behavior change.

## Why

Downstream, `LambdatestIncPrivate/hyperexecute-postprocessing-service` consumes this fork via `git+https://github.com/LambdaTest/cucumber-html-reporter#develop` in its `report-processor/package.json`. Image scans there now hard-block on the GHSA (grace days expired). The downstream is currently working around it via an in-Dockerfile `npm pack uuid@14.0.0` overlay + `sed` patch on `lib/reporter.js` ([hyperexecute-postprocessing-service#1304](https://github.com/LambdatestIncPrivate/hyperexecute-postprocessing-service/pull/1304)). Once this lands and the downstream re-pulls `develop`, that workaround can be reverted.

## Verification

End-to-end in `node:20`:

- [x] `npm install` resolves `uuid` to `14.0.0`.
- [x] `node --check lib/reporter.js` passes.
- [x] `require("./index.js")` loads the module without error.
- [x] `npm test` (which runs `test/createHtmlReports.js`) succeeds: all 4 HTML reports — `cucumber_report_hierarchy.html`, `cucumber_report_bootstrap.html`, `cucumber_report_foundation.html`, `cucumber_report_simple.html` — generate, both standard and stage-rerun variants.

## Type of change

- [x] Security fix
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change

## Related

- Upstream Jira: [TE-12431](https://lambdatest.atlassian.net/browse/TE-12431) (Cigna/Evernorth — escalated, the original AssertionError-class-preservation fix; the uuid CVE blocker surfaced on that customer's deploy path)
- Downstream PR (workaround that can be reverted after this merges): [hyperexecute-postprocessing-service#1304](https://github.com/LambdatestIncPrivate/hyperexecute-postprocessing-service/pull/1304)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[TE-12431]: https://lambdatest.atlassian.net/browse/TE-12431?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ